### PR TITLE
Add support for legacy database writers

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -19,10 +19,12 @@ locals {
       }
     ]
     ], [
-    for database in local.databases : {
-      role     = "postgres"
-      database = database
-    }
+    for database in local.databases : [
+      for writer in var.legacy_writers : {
+        role     = writer
+        database = database
+      }
+    ]
   ]))
 
   privileges_ro = [

--- a/locals.tf
+++ b/locals.tf
@@ -11,14 +11,19 @@ locals {
       }
     ]
   ])
-  databases_writers = flatten([
+  databases_writers = flatten(concat([
     for role, role_ in var.roles : [
       for database in role_.databases_rw : {
         role     = role
         database = database
       }
     ]
-  ])
+  ], [
+    for database in local.databases : {
+      role     = "postgres"
+      database = database
+    }
+  ]))
 
   privileges_ro = [
     "SELECT",

--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,7 @@ locals {
         database = database
       }
     ]
-  ], [
+    ], [
     for database in local.databases : {
       role     = "postgres"
       database = database

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "legacy_writers" {
+  type    = list(string)
+  default = []
+}
+
 variable "roles" {
   type = map(object({
     databases_ro = list(string)


### PR DESCRIPTION
~~Might need to be extended eventually to cover other "legacy" accounts as well.~~

Roles managed through `google_sql_user` resources can be included this way in the default privileges where needed.