### PR TITLE
Fix deprecated number property of random_password

### DIFF
--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -122,7 +122,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = true
       + upper       = true
@@ -444,7 +444,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true
@@ -459,7 +459,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true
@@ -474,7 +474,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -321,7 +321,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true
@@ -336,7 +336,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true
@@ -351,7 +351,7 @@ Terraform will perform the following actions:
       + min_numeric = 0
       + min_special = 0
       + min_upper   = 0
-      + number      = true
+      + numeric     = true
       + result      = (sensitive value)
       + special     = false
       + upper       = true

--- a/roles.tf
+++ b/roles.tf
@@ -8,12 +8,12 @@ resource "random_password" "role" {
   min_upper   = 0
 
   lower   = true
-  number  = true
+  numeric = true
   special = false
   upper   = true
 
   lifecycle {
-    ignore_changes = [lower, number, special, upper]
+    ignore_changes = [lower, numeric, special, upper]
   }
 }
 


### PR DESCRIPTION
```
  ╷
  │ Warning: Attribute Deprecated
  │ 
  │   with module.psql_roles.random_password.role,
  │   on .terraform/modules/psql_roles/roles.tf line 11, in resource "random_password" "role":
  │   11:   number  = true
  │ 
  │ **NOTE**: This is deprecated, use `numeric` instead.
  │ 
  │ (and 15 more similar warnings elsewhere)
  ╵
  ╷
  │ Warning: Deprecated attribute
  │ 
  │   on .terraform/modules/psql_roles/roles.tf line 16, in resource "random_password" "role":
  │   16:     ignore_changes = [lower, number, special, upper]
  │ 
  │ The attribute "number" is deprecated. Refer to the provider documentation
  │ for details.
  ╵
```